### PR TITLE
Allow rspec-rails and rspec-core

### DIFF
--- a/lib/yourbase/rspec/skipper.rb
+++ b/lib/yourbase/rspec/skipper.rb
@@ -1,4 +1,3 @@
-
 module YourBase
   module RSpec
     module Skipper 
@@ -19,23 +18,21 @@ begin
   using_rspec = false
 
   begin 
-    require 'rspec'
+    require 'rspec/core'
     using_rspec = true
-  rescue LoadError => e 
+  rescue LoadError => e
     puts "YourBase can't accelerate RSpec because it's not loaded!"
+    return
   end
 
-  if using_rspec
-    begin
-      puts "Loading YourBase RSpec Skipper..."
-      require 'yourbase_test_skipper'
-      ::YourBase::RSpec::Skipper.inject!
-    rescue LoadError => e
-      puts "Failed to find or load RSpec accelerator, falling back to normal behavior"
-    end
+  begin
+    puts "Loading YourBase RSpec Skipper..."
+    require 'yourbase_test_skipper'
+    ::YourBase::RSpec::Skipper.inject!
+  rescue LoadError => e
+    puts "Failed to find or load RSpec accelerator, falling back to normal behavior"
   end
 
 rescue => e
   puts "Unable to load RSpec accelerator: #{e}"
 end
-


### PR DESCRIPTION
We currently only allow users of the [`rspec`][rspec] gem, which is a meta-gem that wraps several other gems like [`rspec-core`][rspec-core] and [`rspec-mocks`][rspec-mocks]. There are many other ways to use RSpec, including using only `rspec-core` or using another meta-gem like [`rspec-rails`][rspec-rails].

This change allows those ways to still hook into our skipper.

[rspec]: https://github.com/rspec/rspec
[rspec-core]: https://github.com/rspec/rspec-core
[rspec-mocks]: https://github.com/rspec/rspec-mocks
[rspec-rails]: https://github.com/rspec/rspec-rails